### PR TITLE
Fix files not being shown if there is only one

### DIFF
--- a/chapter-15/photo-album/routes/gallery.js
+++ b/chapter-15/photo-album/routes/gallery.js
@@ -15,7 +15,7 @@ router.get('/', (req, res, next) => {
 
       const data = {
         path: 'images/',
-        files: files.splice(1,files.length) // remove the .gitignore
+        files: files
       };
       res.json(data);
   });


### PR DESCRIPTION
In the public/images folder. There is no .gitignore in the folder, so
there's no need to ignore the first file in the folder, and it's
misleading since on the first upload, the photo-album looks empty.